### PR TITLE
Fix more grammatical and typos

### DIFF
--- a/canvas/color_constants.md
+++ b/canvas/color_constants.md
@@ -125,7 +125,7 @@ Note: all the darkened colors are essentially the same color but with all three 
 
 ### Gameplay colors
 
-Note: the gameplay colors are combined with transparency, so it may seem counterintuitive that items like the gray notification is actually completely black, but that's just black with transparency.
+Note: the gameplay colors are combined with transparency, so it may seem counterintuitive that items like the gray notification are actually completely black, but that's just black with transparency.
 
 - Grid
   - fill: #cdcdcd

--- a/canvas/scaling.md
+++ b/canvas/scaling.md
@@ -37,18 +37,18 @@ const a = 1080 / 1080;
 const b = 2000 / 1920;
 return 1.0416 < 1 ? 1 : 1.0416; // this will yield 1.0416
 ```
-This will cause `windowScaling()` to depend on the width for scaling, so that changing the width will have noticeable effect in the scaling.
+This will cause `windowScaling()` to depend on the width for scaling so that changing the width will have a noticeable effect on the scaling.
 
 If our window was longer than 16:9, the scaling will depend on the height.
 
 ## scalingFactor
 
-The units for this is (canvas pixels / diep units). This value is fundamental for converting between diep units and canvas pixels.
+The units for this are (canvas pixels / Diep units). This value is fundamental for converting between Diep units and canvas pixels.
 
 This value is calculated using `scalingFactor = fov * windowScaling()`
 
 Examples of how to convert from one another:
-- 10 diep units * scalingFactor gives us canvas pixels
-- 10 canvas pixels / scalingFactor gives us diep units
+- 10 Diep units * scalingFactor gives us canvas pixels
+- 10 canvas pixels / scalingFactor gives us Diep units
 
-Some remarks: this value only appears when diep draws the grid. It draws the grid by first drawing a portion of the grid onto a separate canvas (with scaling of 1 canvas pixel = 1 diep unit), then using createPattern to draw the entire grid. Before drawing the grid onto the main canvas however, it setTransforms the main canvas so that the horizontal and vertical scaling is equal to the scalingFactor.
+Some remarks: this value only appears when Diep draws the grid. It draws the grid by first drawing a portion of the grid onto a separate canvas (with scaling of 1 canvas pixel = 1 Diep unit), then using createPattern to draw the entire grid. Before drawing the grid onto the main canvas, however, it setTransforms the main canvas so that the horizontal and vertical scaling is equal to the scalingFactor.

--- a/canvas/shape_sizes.md
+++ b/canvas/shape_sizes.md
@@ -1,6 +1,6 @@
 # Shape Sizes
 
-The shapes are not drawn by side length. They are drawn by radius (from the center to any of the verticies).
+The shapes are not drawn by side length. They are drawn by radius (from the center to any of the vertices).
 
 The following is the collected data:
 

--- a/entities.md
+++ b/entities.md
@@ -1,8 +1,8 @@
 # Entities
 
-This document will provide a perspective/overview on how the entire game's networking and entity management system works as a whole.
+This document will provide a perspective / overview on how the entire game's networking and entity management system works as a whole.
 
-From a developer standpoint, you can think of an entity as an object, it has properties that are stored / sent to the client. Entities are identified by a (not fully understood) <id, hash> system. In this system there is a unique identifier `id` is given to every entity, and while that `id` is being used, no other entity may share it. There is also a hash that is sent, which tracks how many times the id has in use during the arena's uptime.
+From a developer standpoint, you can think of an entity as an object, it has properties that are stored/sent to the client. Entities are identified by a (not fully understood) <id, hash> system. In this system, there is a unique identifier for every entity, aka `id`. No two entities alive can share the same `id`. The hash part of the system tracks how many entities a specific `id` has been used for during the arena's uptime. This is for better analysis of desynchronizations.
 
 The following code was sent by Zeach in a screenshot during a conversation regarding the <id, hash> system. It shows how entity ids are encoded before being sent to the client. More information on entity id encodings can be found [here](/protocol/data.md#entid---vu-hash-vu-id).
 
@@ -24,13 +24,13 @@ inline void Encode(BinData &out) const {
 
 ## Fields
 
-Fields, like stated earlier, are basically the equivalent of how properties are to objects, but for entities. Fields are used to describe all things in the game, for example the Arena entity has leaderX and leaderY fields, while also having fields that related to other things like sides. Fields can also have multi length values, like scoreboardNames, which is an array of scoreboard names (encoded as an xor jump table); also another property on the arena entity. For each build, all the fields are randomly shuffled (this is done in the builder) so that there is a randomly(?) selected index for each field; Being 68 fields, there are always 68 indexes. These field indexes are used for the protocol, and for the offsets in the memory. All fields and located [here](about:blank)
+Fields, as stated earlier, are basically the equivalent of how properties are to objects, but for entities. Fields are used to describe all things in the game. For example, the Arena entity has leaderX and leaderY fields, while also having fields that are related to other things like sides. Fields can also have multi-length values, like scoreboardNames, which is an array of scoreboard names (encoded as a xor jump table); also another property on the arena entity. For each build, all the fields are randomly shuffled (this is done in the builder) so that there is a randomly(?) selected index for each field; Being 68 fields, there are always 68 indexes. These field indexes are used in the protocol and to determine the field offsets in the memory. All fields and located [here](about:blank)
 
 ---
 
 ## Field Groups + Purpose
 
-These fields are all organized into groups, known as field groups. For each field there is a constant (throughout builds) id per field group. So for example, the field `maxHealth` is in the Health field group, and its field-group specific id is 2 across all updates. You can see the field groups and field ids per fields [here](about:blank). Here are the list of field group names by id (empty = deleted / not in code)
+These fields are all organized into groups, known as field groups. For each field, there is a constant (throughout builds) id per field group. So for example, the field `maxHealth` is in the Health field group, and its field-group specific id is 2 across all updates. You can see the field groups and field ids per field [here](about:blank). Here is the list of field group names by id (empty = deleted / not in code)
 ```
 0 : RELATIONSHIPS
 1 : 
@@ -56,14 +56,14 @@ Field groups are also used for the organization of entities, but that will be ex
 
 ## Parsing
 
-Only one packet is used to update entities in game. The [0x00 Update Packet](https://github.com/ABCxFF/diepindepth/blob/main/protocol/update.md#0x00-update-packet). Most of what will be said here will be explained more in depth on that page. 
+Only one packet is used to update entities in-game. The [0x00 Update Packet](https://github.com/ABCxFF/diepindepth/blob/main/protocol/update.md#0x00-update-packet). Most of what will be said here will be explained more in-depth on that page. 
 
-Entities can only be created, deleted, or updated in the game. In the 0x00 packet format, there are two arrays (`vu32(len), ...elems`). An array of [`entid`](https://github.com/ABCxFF/diepindepth/blob/main/protocol/data.md#entid---vu-hash-vu-id)s to be deleted from the clients's entity storage, and an array of `upcreates`, which are either updates or creations. Creations contain full data about an entity, whereas updates only update specific fields at a time. More info, as stated earlier, is on the [0x00 Update Packet](https://github.com/ABCxFF/diepindepth/blob/main/protocol/update.md#0x00-update-packet) page.
+Entities can only be created, deleted, or updated in the game. In the 0x00 packet format, there are two arrays (`vu32(len), ...elems`). An array of [`entid`](https://github.com/ABCxFF/diepindepth/blob/main/protocol/data.md#entid---vu-hash-vu-id)s to be deleted from the clients' entity storage, and an array of `upcreates`, which are either updates or creations. Creations contain full data about an entity, whereas updates only update specific fields at a time. More info, as stated earlier, is on the [0x00 Update Packet](https://github.com/ABCxFF/diepindepth/blob/main/protocol/update.md#0x00-update-packet) page.
 
 ---
 
 ## Memory
 
-> Discuss basics how entities look / interact in the memory.
+> Discuss the basics of how entities look / interact in the memory.
 
 

--- a/memory/structs/README.md
+++ b/memory/structs/README.md
@@ -1,3 +1,3 @@
 # Structures
 
-Mostly reversed structures are posted here in pseudo c struct like format. Also javascript for what we call "cstr"s (maybe we'll call it emscripten string? looking for a new name still)
+Mostly reversed structures are posted here in pseudo-c struct-like format. Also javascript for what we call "cstr"s (maybe we'll call it Emscripten string? Looking for a new name still...)

--- a/protocol/connection/api.md
+++ b/protocol/connection/api.md
@@ -1,14 +1,14 @@
 # [`M28 API`](https://api.n.m28.io/)
 
-The M28 api has only 3 api paths that relate to diep: `/server`, `endpoint/diepio-${gamemode}`, and `endpoint/latency`. All but `/server` are necessary to the client when connecting to a gamemode server.
+The M28 api has only 3 api paths that relate to Diep: `/server`, `endpoint/diepio-${gamemode}`, and `endpoint/latency`. All but `/server` is necessary to the client when connecting to a gamemode server.
 
-First, its worth mentioning that to connect to a server by id, append `.s.m28n.net` to its id. Example would be id=`abcd`, ws server=`wss://abcd.s.m28n.net`.
+First, it's worth mentioning that to connect to a server by id, append `.s.m28n.net` to its id. An example would be id=`abcd`, ws server=`wss://abcd.s.m28n.net`.
 
 ---
 
 ## [`/server`](https://api.n.m28.io/server/diepindepth) Endpoint
 
-This endpoint responds with info about a server via its ID. Unlike the other endpoints, this endpoint is part of the M28 api system, and is not part of some sort of game or game server.
+This endpoint responds with info about a server via its ID. Unlike the other endpoints, this endpoint is part of the M28 api system and is not part of some sort of game or game server.
 
 URL -> `https://api.n.m28.io/server/{server-id}`
 
@@ -32,7 +32,7 @@ Content-Length: 87
 
 ## DiepIO Game Server Endpoints
 
-This endpoint lists servers hosted on the m28 server api for diep.io. It is used to find a server by gamemode, one server per region is listed, so there may be more in the region than shown..
+This endpoint lists servers hosted on the m28 server api for diep.io. It is used to find a server by gamemode, one server per region is listed, so there may be more in the region than shown.
 
 URL `https://api.n.m28.io/endpoint/diepio-{gamemode}/findEach`
 
@@ -76,7 +76,7 @@ Content-Length: 523
 }
 ```
 
-> There is also a gamemodeless request that gives all servers, regardless of gamemode, `https://api.n.m28.io/endpoint/diepio/findEach` - this is no longer being used in production.
+> There is also a gamemode-less request that gives all servers, regardless of gamemode, `https://api.n.m28.io/endpoint/diepio/findEach` - this is no longer being used in production.
 
 ---
 
@@ -84,7 +84,7 @@ Content-Length: 523
 
 Similar to the others, this endpoint returns servers based on region, but they are not diep.io servers - they are latency servers. Upon connecting to these servers (via ws) and sending any data that is prefixed with a null byte, the server will echo back the same buffer.
 
-Diep.io uses these servers to find out the best region to connect to, by sending a 0x00 byte, and then calculating the time between sending the byte and receiving the echo. Whichever has the least time between sending and receiving will be the region you will eventually connect to when selecting gamemode servers.
+Diep.io uses these servers to find out the best region to connect to, by sending a 0x00 byte and then calculating the time between sending the byte and receiving the echo. Whichever has the least time between sending and receiving will be the region you will eventually connect to when selecting gamemode servers.
 
 URL -> `https://api.n.m28.io/endpoint/latency/findEach`
 

--- a/protocol/connection/headless.md
+++ b/protocol/connection/headless.md
@@ -2,9 +2,9 @@
 
 # Headless Connection
 
-## M28 Api
+## M28 API
 
-To find a server, you'll need to retrieve a server id from the m28 api, from there you can generate a socket url which you can connect to - all of which is described in the first passage of [api.md](./api.md).
+To find a server, you'll need to retrieve a server id from the m28 api, from there you can generate a socket URL which you can connect to - all of which is described in the first passage of [api.md](./api.md).
 
 - Connections are always secure
 
@@ -12,7 +12,7 @@ To find a server, you'll need to retrieve a server id from the m28 api, from the
 
 ## HTTP Headers
 
-Diep.io currently has many security measures to block out headless connection. One of these securities is a strict checking of HTTP headers on incoming websocket connections, and so we need to override this and connect with browser-like headers.
+Diep.io currently has many security measures to block out headless connections. One of these securities is strict checking of HTTP headers on incoming WebSocket connections, and so we need to override this and connect with browser-like headers.
 
 Credit to Binary:
 
@@ -35,11 +35,11 @@ https.get = new Proxy(https.get, {apply(target, thisArg, args)
 ```
 
 There are 2 rules the HTTP headers must satisfy:
-- The headers `User-Agent`, `Pragma` and `Cache-Control` must exist, otherwise your connection will get rejected with a [403](https://httpstatuses.com/403) response code. They can simply be left empty or have a fake value, however M28 may begin to check for this at any time so it is recommended to provide realistic values.
-- The `Host` header must be anywhere above the `Origin` and `Sec-WebSocket-Key` headers, this is true with every modern browser except for the [ws](https://www.npmjs.com/package/ws) module. Nothing happens if you fail this check, you will not get disconnected or banned. Instead, the server will send completely random packets to try trick you into thinking that you got packet shuffling wrong.
+- The headers `User-Agent`, `Pragma` and `Cache-Control` must exist, otherwise, your connection will get rejected with a [403](https://httpstatuses.com/403) response code. They can simply be left empty or have a false value, however, Zeach may begin to check for this at any time so it is recommended to provide realistic values.
+- The `Host` header must be anywhere above the `Origin` and `Sec-WebSocket-Key` headers, this is true with every modern browser except for the [ws](https://www.npmjs.com/package/ws) module. Nothing happens if you fail this check, you will not get disconnected or banned. Instead, the server will send completely random packets to try to trick you into thinking that you got packet shuffling wrong.
 
 ## Initiation and Packet Encoding / Decoding
 
 The first packet send is always the [0x00 Init packet](../outgoing.md#0x00-init-packet), and this does not have to be encoded. The following packet will either be a [0x01 Invalid Build](../incoming.md#0x01-outdated-client-packet), or an encoded [JS Int Eval packet](../incoming.md#0x0d-int-js-challenge-packet) (or sometimes a [PoW Challenge](./incoming.md#0x0b-pow-challenge-packet)). Sending encoded and decoding incoming packets will be explained fully in [api.md](./crypto.md). 
 
-> some more info
+> Some more info

--- a/protocol/crypto.md
+++ b/protocol/crypto.md
@@ -3,7 +3,7 @@
 
 # Packet Encoding and Decoding
 
-Also known as shuffling/unshuffling, this encryption system is what annoys 80% of all the people who deal with diep protocol. No one has fully reverse engineered every part of the encryption system, but Shädam got close, and was able to reverse engineer (for the most part) packet opcode/header encodings, and content encodings. Some of his old code is visible on repos in his account.
+Also known as shuffling/unshuffling, this encryption system is what annoys 80% of all the people who deal with Diep protocol. No one has fully reverse-engineered every part of the encryption system, but Shädam got close and was able to reverse-engineer (for the most part) packet opcode/header encodings, and content encodings. Some of his old code is visible in a repository on his account.
 
 > Add some broad statements here
 
@@ -21,7 +21,7 @@ There are 3 parts to packet encryption:
 
 ## Packet Content Encryption
 
-> the *n* length xor tables, how they're genereated
+> the *n* length xor tables, how they're generated
 
 ## Packet Header Encryption
 

--- a/protocol/data.md
+++ b/protocol/data.md
@@ -121,7 +121,7 @@ The hash: This seems to be the total amount of times a specific id has been used
 
 ### **Data Organization**
 
-Inside of specifically 0x00 packets, there is a form of table which has come to be known as a "jump table. Jump tables work differently than the standard arrays, by retrieving indexes from jumps, then parsing values based on that index. The best way to explain the format is with an example, here is an example of a field group identification table, without any values.
+Inside of 0x00 packets, there is data stored in a table-like form of data, which has come to be known as a "jump table". Jump tables work differently than standard arrays. They are parsed by retrieving indexes from jumps, then parsing values based on that index. The best way to explain the format is with an example, here is an example of a field group identification jump table, in this case, indexes without any values.
 
 ```
 

--- a/protocol/data.md
+++ b/protocol/data.md
@@ -54,13 +54,13 @@ enum class ID {
 
 ### **`tank`** - `vi`
 
-A varint encoded tank id, defaults to -1. Tanks are listed [here](/extras/tanks.js), and their in depth definitions [here](/extras/tankdefs.json)
+A varint encoded tank id, defaults to -1. Tanks are listed [here](/extras/tanks.js), and their in-depth definitions [here](/extras/tankdefs.json)
 
 ---
 
 ### **`bitflags`** - `vu`
 
-A varuint encoded series of bit flags with varying value. Example would be the outgoing input packet:
+A varuint encoded series of bit flags with varying values. An example would be the outgoing input packet:
 
 ```
 00000001 ; u8 ; header
@@ -89,7 +89,7 @@ The flags are read as a varuint, which for this example results in 2073. This ca
 
 ### **`entid`** - `<vu: hash, vu: id>`
 
-A way of storing hash and id used in the <id, hash> system. Sent from Zeach (besides comments), the server's entid encoder:
+A way of storing hash and id is used in the <id, hash> system. Sent from Zeach (besides comments), the server's entid encoder:
 
 ```c++
 /*
@@ -112,16 +112,16 @@ inline void Encode(BinData &out) const {
 }
 ```
 
-The id: A universal identifier which is unique while the entity is alive, but once the entity is destroyed - the id may be used by another entity in the future. **IDs are unique, but can be recycled**
-The hash: Seems to be the total amount of times a specific id has been used/recycled.
+The id: A universal identifier that is unique while the entity is alive, but once the entity is destroyed - the id may be used by another entity in the future. **IDs are unique, but can be recycled**
+The hash: This seems to be the total amount of times a specific id has been used/recycled.
 
-**Quick Misconception,** in diep's console, sometimes you'll see messages relating to _"possible desyncs"_ and alongside them you'll see two numbers inside of these `<triangular bracket things>`, these are NOT `<hash, id>`. Unlike the order they are read, entids are logged as `<id, hash>` in the diep console.
+**Quick Misconception,** in Diep's console, sometimes you'll see messages relating to _"possible desyncs"_ and alongside them, you'll see two numbers inside of these `<triangular bracket things>`, these are NOT `<hash, id>`. Unlike the order they are read, entids are logged as `<id, hash>` in the Diep console.
 
 ---
 
 ### **Data Organization**
 
-Inside of a specifically 0x00 packets, there is a form of table which has come to be known as a `jumpTable`. Jump tables work differently than the standard arrays, by retrieving indexes from jumps, then parsing values based on index. The best way to explain the format is with an example, here is an example of a field group identification table, without any values.
+Inside of specifically 0x00 packets, there is a form of table which has come to be known as a "jump table. Jump tables work differently than the standard arrays, by retrieving indexes from jumps, then parsing values based on that index. The best way to explain the format is with an example, here is an example of a field group identification table, without any values.
 
 ```
 
@@ -168,7 +168,7 @@ no value being read
 
 The resulting indexes from this jump table were [0, 3, 4, 5, 8, 10, 11, 13]. More about what these values mean in [`incoming.md`](/packets/incoming.md)
 
-And for more understanding, here's two jump table readers written in Javascript and C++
+And for more understanding, here are two jump table readers written in Javascript and C++
 
 ```c++
 template<typename function>
@@ -183,7 +183,7 @@ auto jumpTable(function read) {
 
         if(currentJump == 0) break; // If there is no jump, exit
 
-        index += currentJump; // jump to the next index
+        index += currentJump; // Jump to the next index
         table.push_back(read(index)); // Read according to index
     }
     return table;
@@ -203,7 +203,7 @@ jumpTable(read) {
 
         if (!currentJump) break; // If there is no jump, exit
 
-        index += currentJump; // jump to the next index
+        index += currentJump; // Jump to the next index
         table[table.length++] = read.call(this, index); // Read according to index
     }
 
@@ -211,4 +211,4 @@ jumpTable(read) {
 }
 ```
 
-Understanding of this data structure takes practice, at first it may be difficult to understand, but over time it will be easily understandable and identifiable.
+Understanding this data structure takes practice, at first it may be difficult to understand, but over time it will be easily understandable and identifiable.

--- a/protocol/incoming.md
+++ b/protocol/incoming.md
@@ -25,13 +25,13 @@ For information on data types and encodings, see [`data.md`](./data.md)
 
 ## **`0x00` Update Packet**
 
-Contains created/updated/deleted entities and current ingame time. Too much to explain here, it'd be easier just putting it in [`update.md`](./update.md).
+Contains created/updated/deleted entities and current ingame time. There is too much to explain here, it'd be easier just putting it in [`update.md`](./update.md).
 
 ---
 
 ## **`0x01` Outdated Client Packet**
 
-Sent when the client's build (which is sent in the [`0x00` Init Packet](./outgoing.md#0x00-init-packet)) is not the same as the server's. The server sends the latest build, and when the client receives it, the page reloads. This packet is by naturally unencoded, meaning its data is sent raw unencoded. This is since if you have an invalid build you won't be able to decode packets.
+Sent when the client's build (which is sent in the [`0x00` Init Packet](./outgoing.md#0x00-init-packet)) is not the same as the server's. The server sends the latest build, and when the client receives it, the page reloads. This packet is by nature unencoded, meaning its data is sent raw, unencoded. This is since if you have an invalid build you won't be able to decode packets properly.
 
 
 Format: 
@@ -64,13 +64,13 @@ At the start of the packet there is a u32 specifying the final length of the dec
 Format:
 > `02 u32(decompressed output length) (LZ4 block)`
 
-The decompressed result will include the packet header, you should feed this into your parsing function recursively. The decompressed result is not [encoded](./encoding.md). Currently only [Update](./incoming.md#0x00-update-packet) and [Eval](./incoming.md#0x0d-int-js-challenge-packet) packets can get large enough to be compressed.
+The decompressed result will include the packet header, you should feed this into your parsing function recursively. The decompressed result is not [encoded](./encoding.md). Currently only [Update](./incoming.md#0x00-update-packet) and [JS Challenge](./incoming.md#0x0d-int-js-challenge-packet) packets can get large enough to be compressed.
 
 ---
 
 ## **`0x03` Notification Packet**
 
-This packet sends data which trigger the notifications you see in game, for example messages like "The Guardian has spawned". 
+This packet sends data that trigger the notifications you see in-game, for example, messages like "The Guardian has spawned" and "You've killed Example". 
 
 The Red Green Blue values are encoded as a u32. For example, rgb(33, 130, 67) would be the same as u32(0x218243) where each byte is a color. The fourth byte is not used, there is no alpha channel. The time the notification appears in milliseconds is encoded as a float, and the final value part of this packet is the notification identifier.  
 
@@ -88,7 +88,7 @@ Format:
 
 ---
 
-It's worth nothing that not all notifications are sent throught this packet. The autofire, autospin, gamepad_enabled and adblock notifications are fully clientside while the rest are received from the server.
+It's worth noting that not all notifications are sent through this packet. The autofire, autospin, gamepad_enabled, and adblock notifications are fully clientside while the rest are received from the server.
 
 ## **`0x04` Server Info Packet**
 
@@ -107,7 +107,7 @@ incoming <- 04 stringNT("sandbox") stringNT("vultr-amsterdam")
 
 ## **`0x05` Heartbeat Packet**
 
-Part of the game's latency system. Once receieved, the client immediately echoes the single byte [`0x05` packet](./outgoing.md#0x05-heartbeat-packet) back. 🏓
+Part of the game's latency system. Once received, the client immediately echoes the single-byte [`0x05` packet](./outgoing.md#0x05-heartbeat-packet) back. 🏓
 
 Format:
 > `05`
@@ -154,7 +154,7 @@ The final link is `diep.io/#2627C6D600D2DC30453C`
 
 ## **`0x07` Accept Packet**
 
-This packet is sent once the game server has accepted the client (correct build, valid or no party). As of Feb 25, the server only accepts the client once the client solves a [JS](./incoming.md#0x0d-int-js-challenge-packet) and [PoW](./incoming.md#0x0b-pow-challenge-packet) challenge.
+This packet is sent once the game server has accepted the client (correct build, valid or no party). As of Feb 25, the server only accepts the client once the client solves a [JS Challange](./incoming.md#0x0d-int-js-challenge-packet) and [PoW](./incoming.md#0x0b-pow-challenge-packet) challenge.
 
 Format:
 > `07`
@@ -178,7 +178,7 @@ incoming <- 08 vu(6) stringNT("9898db9ff6d3c1b3_1") stringNT("300ddd6f1fb3d69d_1
 
 ## **`0x09` Invalid Party Packet**
 
-This single byte packet is sent if the party code you specified in the [Init Packet](./outgoing.md#0x00-init-packet) is invalid. You will get this instead of the [`0x07`](./incoming.md#0x07-accept-packet) packet, only after solving a [JS](./incoming.md#0x0d-int-js-challenge-packet) and [PoW](./incoming.md#0x0b-pow-challenge-packet) challenge.
+This single byte packet is sent if the party code you specified in the [Init Packet](./outgoing.md#0x00-init-packet) is invalid. You will get this instead of the [`0x07`](./incoming.md#0x07-accept-packet) packet, only after solving a [JS Challange](./incoming.md#0x0d-int-js-challenge-packet) and [PoW](./incoming.md#0x0b-pow-challenge-packet) challenge.
 
 Format:
 > `09`
@@ -196,7 +196,7 @@ window.alert('Invalid party ID');
 
 ## **`0x0A` Player Count Packet**
 
-This packet is sent occasionally, sending the total client count encoded in a varuint. This updates the text on the bottom right of the screen "*n* players". This packet is not sent globally across all server at the same time, but the exact ticks before a player count update is unknown.
+This packet is sent occasionally, sending the total client count encoded in a varuint. This updates the text on the bottom right of the screen "*n* players". This packet is not sent globally across all servers at the same time, and the exact ticks before a player count update are unknown.
 
 Format:
 > `0A vu(client count)`
@@ -231,7 +231,7 @@ m28.pow.solve("5X6qqhhfkp4v5zf2", 20).then(solveStr => {
 
 ## **`0x0C` Unnamed Packet**
 
-This packet has never been observed, and while the packet's format has been reversed, its never used and does not affect the client. On an older version this was the same as the [`0x0D` Int JS Challenge](./incoming.md#0x0d-int-js-challenge-packet) packet, except it expected a string as a response. So we can't be sure if this packet is still the same as it was and is just not fully present due to emscripten simplifications, or if it changed completely.
+This packet has never been observed, and while the packet's format has been reversed, it's never used and does not affect the client. On an older version this was the same as the [`0x0D` Int JS Challenge](./incoming.md#0x0d-int-js-challenge-packet) packet, except it expected a string as a response. So we can't be sure if this packet is still the same as it was and is just not fully present due to [Emscripten](https://github.com/emscripten-core/emscripten) simplifications, or if it changed completely.
 
 Format:
 > `0C vu(unknown)`
@@ -242,7 +242,7 @@ Format:
 
 This packet is sent only once, during the client -> server acceptance handshake. It sends highly obfuscated code to be evaluated by the client with the purpose of filtering out headless clients from clients on the web - part of diep.io's anti botting system. The result of this code is always an uint32 and is sent back to the client through the outgoing [`0x0B` JS Result](./outgoing.md#0x0b-js-result-packet) packet.
 
-The code sent is obfuscated with [obfuscator.io](https://obfuscator.io/), almost all settings turned on max. This packet checks for global objects and specific properties on global objects, if all the checks pass their intended result, the code ends up returning the correct uint32 result, which the game server recognises and continues (or completes) the process of accepting the client. 
+The code sent is obfuscated with [obfuscator.io](https://obfuscator.io/), almost all settings turned on max. This packet checks for global objects and specific properties on global objects, if all the checks pass their intended result, the code ends up returning the correct uint32 result, which the game server recognizes and continues (or completes) the process of accepting the client. 
 
 > Fun fact:
 > -  There are only 200 unique obfuscated evaluation codes that can be sent to the client, and they are reused across all servers and are generated during the building process (per update).

--- a/protocol/outgoing.md
+++ b/protocol/outgoing.md
@@ -28,7 +28,7 @@ The first packet, and the only unencoded one. This packet is sent to initiate th
 Format:
 > `00 string(build hash) string(dev password) string(party code) vu(debug val)`
 
-The dev confirmed that this format is correct, but did not give any information on the varuint at the end of the packet, only that it was only active during "debug builds". If the build sent by the client is the not the same as the one the server is expecting, the server responds with a [`0x01` Outdated Client](./incoming.md#0x01-outdated-client-packet) packet.
+The dev confirmed that this format is correct, but did not give any information on the varuint at the end of the packet, only that it was only active during "debug builds". If the build hash sent by the client is not the same as the one the server is expecting, the server responds with a [`0x01` Outdated Client](./incoming.md#0x01-outdated-client-packet) packet.
 
 ---
 
@@ -38,20 +38,20 @@ The most frequently sent packet coming from the client, sends movement flags, mo
 
 ```
 bit  ; name             ; desc
-x001 ; fire             ; Set when left mouse / spacebar is down or autofire is on
-x002 ; up key           ; Set when up key is down
-x004 ; left key         ; Set when left key is down
-x008 ; down key         ; Set when down key is down
-x010 ; right key        ; Set when right key is down
+x001 ; fire             ; Set when left mouse / spacebar is pressed down or autofire is on
+x002 ; up key           ; Set when the up key is pressed down
+x004 ; left key         ; Set when the left key is pressed down
+x008 ; down key         ; Set when the down key is pressed down
+x010 ; right key        ; Set when the right key is pressed down
 x020 ; god mode toggle  ; Set when god mode is toggled
-x040 ; suicide key      ; Set when suicide key is down
-x080 ; right mouse      ; Set when shift / right click is down
-x100 ; instant upgrade  ; Set when upgrade key is down
-x200 ; use gamepad      ; Set when gamepad is being used instead of keyboard
-x400 ; switch class     ; Set when switch class key is toggled
+x040 ; suicide key      ; Set when the suicide key is pressed down
+x080 ; right mouse      ; Set when shift / right click is pressed down
+x100 ; instant upgrade  ; Set when upgrade key is pressed down
+x200 ; use gamepad      ; Set when a gamepad is being used instead of a keyboard
+x400 ; switch class     ; Set when switch class key is pressed down
 ```
 
-For information on how these are encoded, see [`data.md`](./data.md#bitflags---vu) where the example is actually a sample input packet. If the gamepad flag is set, then two additional varfloats are appended to the packet, representing the gamepad's x axis movement and the gamepad's y axis movement.
+For information on how these are encoded, see [`data.md`](./data.md#bitflags---vu) where the example is actually a sample input packet. If the gamepad flag is set, then two additional varfloats are appended to the packet, representing the gamepad's x-axis movement and the gamepad's y-axis movement.
 
 Format:
 > `01 flags(input flags) vf(world mouse x) vf(world mouse y) gamepad?[vf(gamepad x axis) vf(gamepad y axis)]`
@@ -60,7 +60,7 @@ Format:
 
 ## **`0x02` Spawn Packet**
 
-This packet creates a spawn attempt, we call it an attempt / request because the server waits for you to solve a [Proof of Work challenge](./incoming.md#0x0b-pow-challenge-packet) first before spawning you in. If you are waiting to be spawned in (due to PoW or game starting countdown / players needed), sending another one will change the name you will spawn in with.
+This packet creates a spawning attempt, we call it an attempt / request because the server waits for you to solve a [Proof of Work challenge](./incoming.md#0x0b-pow-challenge-packet) first before spawning you in. If you are waiting to be spawned in (due to PoW or game starting countdown / players needed), sending another one will change the name you will spawn in with.
 
 Format:
 > `02 stringNT(name)`
@@ -116,7 +116,7 @@ magicNum(latest build) % STAT_COUNT; // STAT_COUNT is 8
 
 ## **`0x04` Tank Upgrade Packet**
 
-This packet is sent to upgrade to a tank. Althought it takes the tank id as a parameter in the packet, if the tank selected is not in your upgrade path, or you don't have enough levels to reach it, nothing will happen. The [tank id](/extras/tanks.js) is xored by a remainder of the magicNum, very similar to the `0x03` outgoing packet. This was, like the stat upgrading packet, in an attempt to prevent scripting or automatic upgrading of tanks.
+This packet is sent to upgrade to a tank. Although it takes the tank id as a parameter in the packet, if the tank selected is not in your upgrade path, or you don't have enough levels to reach it, nothing will happen. The [tank id](/extras/tanks.js) is xored by a remainder of the magicNum, very similar to the `0x03` outgoing packet. This was, like the stat upgrading packet, an attempt to prevent scripting or automatic upgrading of tanks.
 
 Format:
 > `04 vi(tank id ^ tank xor)`
@@ -131,7 +131,7 @@ magicNum(latest build) % TANK_COUNT; // TANK_COUNT is 54
 
 ## **`0x05` Heartbeat Packet**
 
-Part of the game's latency system. Once sent, the server immediately echoes the single byte [`0x05`](./incoming.md#0x05-heartbeat-packet) packet back. 🏓
+Part of the game's latency system. Once sent, the server immediately echoes the single-byte [`0x05`](./incoming.md#0x05-heartbeat-packet) packet back. 🏓
 
 Format:
 > `05`
@@ -160,7 +160,7 @@ This packet has never been observed and has only been seen in server code images
     ... code after unknown
 ```
 
-He also talks about it being related to the Mobile version of the game, and is involved in a tpc connection used on mobile.
+He also talks about it being related to the Mobile version of the game and is involved in a tpc connection used on mobile.
 
 
 Format:
@@ -177,7 +177,7 @@ Format:
 
 ## **`0x08` To Respawn Packet**
 
-This peculiar single byte packet is sent whenever you move past the death screen into the respawn screen. The use of this is so that if the arena is closed the server can redirect you to a new arena or disconnect you to cause the client to connect to another server. An example of this would be after an arena is closing in dom, when you move to the respawn screen you will be redirected to the next game.
+This peculiar single-byte packet is sent whenever you move past the death screen into the respawn screen. The use of this is so that if the arena is closed the server can redirect you to a new arena or disconnect you to cause the client to connect to another server. An example of this would be after an arena is closing in domination, when you move to the respawn screen you will be redirected to the next game.
 
 Format:
 > `08`
@@ -204,7 +204,7 @@ Format:
 
 ## **`0x0B` JS Result Packet**
 
-This packet is the evaluated result of the [`0x0D` Int JS Challenge](./incoming.md#0x0d-int-js-challenge-packet) packet. It sends the evaluation id and the result. In older builds, this packet could also be a response to `0x0C` JS String Challenge, which is now no longer fully existing; so this packet is able to encode any type result, meaning that it could send a string or integer.
+This packet is the evaluated result of the [`0x0D` Int JS Challenge](./incoming.md#0x0d-int-js-challenge-packet) packet. It sends the evaluation id and the result. In older builds, this packet could also be a response to `0x0C` JS String Challenge, which is now no longer fully existing; so this packet is able to encode any type of result, meaning that it could send a string or integer.
 
 Format:
 > `0B vu(id) any/vu(result)`

--- a/protocol/outgoing.md
+++ b/protocol/outgoing.md
@@ -151,8 +151,8 @@ incoming -> 05
 
 This packet has never been observed and has only been seen in server code images sent by M28. The following code is the only information we have on it:
 ```c++
-    }else if(cmd == 0x06){ // Aknowledged ES packet
-#ifndef USE_TPC_ES
+    }else if(cmd == 0x06){ // Acknowledged ES packet
+#ifndef USE_TCP_ES
         if(m_pGame != nullptr){
             m_pGame->Simulation()->Entities()->Acknowledged(ID(), view.NextUint32());
         }
@@ -160,7 +160,7 @@ This packet has never been observed and has only been seen in server code images
     ... code after unknown
 ```
 
-He also talks about it being related to the Mobile version of the game and is involved in a tpc connection used on mobile.
+He also talks about it being related to the Mobile version of the game and is involved in a TPC connection used on mobile.
 
 
 Format:

--- a/protocol/update.md
+++ b/protocol/update.md
@@ -1,11 +1,11 @@
 # 0x00 Update Packet
 ---
-The one and only infamous 0x00 update packet contains almost all information you see in the game. If you have not yet read [`/entities.md`](/entities.md), I highly advise you read it, because it directly relates to how update packets work.
+The one and only infamous 0x00 update packet contains almost all the information you see in the game. If you have not yet read [`/entities.md`](/entities.md), I highly advise you to read it, because it directly relates to how update packets work.
 
 The update packet contains server uptick, entity deletions (entities on screen that should be deleted), and entity upcreates (creations of new entities or updates of older entities). The rough format of the 0x00 packet is as follows:
 > `0x00 vu(game tick) vu(deleteCount) ...entity id deletes vu(upcreateCount) ...upcreates`
 
-Two types of things can happen in an upcreate, there can be a creation, and an update (hence the word upcreate). Creations and updates have their own format and are identified in their own way. Both of the data in creations updates though, are organized in a field order, which is the per-build order of all fields.
+Two types of things can happen in an upcreate, there can be creations and / or updates (hence the word upcreate). Creations and updates have different formats and are identified in their own way. Both of the data in creations and updates are organized in a field order, which is the per-build order of all fields.
 > Being 68 fields, there are always 68 indexes. These field indexes are used for the protocol, and for the offsets in the memory. All fields and located here
 Read a bit more about field orders [here](/entities.md#fields)
 ---
@@ -16,7 +16,7 @@ The following are examples of some basic upcreates:
 **Creation**
 > ```less
 > 01 08 # entity id
->    01 # signify creation, and read field groups
+>    01 # signify creation and read field groups
 >    05 01 # field group table
 >    93 02 93 45 28 # data
 > ```
@@ -27,11 +27,11 @@ The following are examples of some basic upcreates:
 >    05 93 02 00 45 # field data
 >    01 # close field
 > ```
-So in updates, after the entity id are bytes `00 01`, and in creations, its just `01` which initiates the [jump table](/protocol/data.md#data-organization).
+So in updates, after the entity id are bytes `00 01`, and in creations, it's just `01` which initiates the [jump table](/protocol/data.md#data-organization).
 
 ### 2. Parsing Creation
 
-Like stated in [`entities.md`](/entities.md), entities are defined by their entity id, entity hash, field groups, and field data, all of which are present in creations. The entity id and hash is encoded in the [entid format](/protocol/data.md#entid---vu-hash-vu-id), the field groups are encoded in a [jump table](/protocol/data.md#data-organization), then fields are retrieved from the field groups, ordered by the shuffled field order, then the data type that corresponds with each field in order is read from the packet. Here's a rough sketch of what it would look like:
+As stated in [`entities.md`](/entities.md), entities are defined by their entity id, entity hash, field groups, and field data, all of which are present in creations. The entity id and hash are encoded in the [entid format](/protocol/data.md#entid---vu-hash-vu-id), the field groups are encoded in a [jump table](/protocol/data.md#data-organization), then fields are retrieved from the field groups, ordered by the shuffled field order, then the data type that corresponds with each field in order is read from the packet. Here's a rough sketch of what it would look like:
 
 > ```less
 > 01 03 # entity id
@@ -45,13 +45,13 @@ Like stated in [`entities.md`](/entities.md), entities are defined by their enti
 >    ...byte /*
 >     *n* number of bytes that have all entity's data
 >     the fields are identified from the field groups and are reordered in the way field IDs were shuffled for the current build
->     the bytes are then read in the order & types of these organized fields
+>     the bytes are then read in order & types of these organized fields
 >     
 >     */
 > ```
 
 Note:
-- To parse tabled fields, such as `leaderboardNames`, you need to know the total amount of values they have. `leaderboardNames` for example has `10`, so you would read 10 null terminating strings which is its data type.
+- To parse tabled fields, such as `leaderboardNames`, you need to know the total amount of values they have. `leaderboardNames` for example has `10`, so you would read 10 null terminating strings which are its data type.
 
 Abstract Format of a Creation:
 

--- a/protocol/update.md
+++ b/protocol/update.md
@@ -6,7 +6,7 @@ The update packet contains server uptick, entity deletions (entities on screen t
 > `0x00 vu(game tick) vu(deleteCount) ...entity id deletes vu(upcreateCount) ...upcreates`
 
 Two types of things can happen in an upcreate, there can be creations and / or updates (hence the word upcreate). Creations and updates have different formats and are identified in their own way. Both of the data in creations and updates are organized in a field order, which is the per-build order of all fields.
-> Being 68 fields, there are always 68 indexes. These field indexes are used for the protocol, and for the offsets in the memory. All fields and located here
+> Being 68 fields, there are always 68 indexes. These field indexes are used in the protocol and to determine the field offsets in the memory. All fields and located here
 Read a bit more about field orders [here](/entities.md#fields)
 ---
 ### 1. How to identify between Creation and Update

--- a/wasm/temp
+++ b/wasm/temp
@@ -1,1 +1,1 @@
-This file can be removed later; it only here to keep the `wasm/` folder as git does not allow folders to be empty.
+This file can be removed later; it is only here to keep the `wasm/` folder as git does not allow folders to be empty.

--- a/wasm/temp
+++ b/wasm/temp
@@ -1,1 +1,1 @@
-This file can be removed, only here to make the wasm/ folder
+This file can be removed later; it only here to keep the `wasm/` folder as git does not allow folders to be empty.


### PR DESCRIPTION
Fix more grammatical and typo~~e~~s that persisted through the other PRs. I, however, haven't attempted to make the flow nicer and make descriptions more succinct, removing redundant and long-winded ways of saying things, which may be possible in the future with another PR.