### PR TITLE
Update LZ4 explanation link

### DIFF
--- a/protocol/clientbound.md
+++ b/protocol/clientbound.md
@@ -56,7 +56,7 @@ reload()
 
 ## **`0x02` Compressed Packet**
 
-When a clientbound packet is big enough, the server sends you a compressed version of the packet instead. The compression algorithm used is LZ4, and it is explained on [Ticki's blog](https://ticki.github.io/blog/how-lz4-works/).
+When a clientbound packet is big enough, the server sends you a compressed version of the packet instead. The compression algorithm used is LZ4, and it is explained [here](http://fastcompression.blogspot.com/2011/05/lz4-explained.html/).
 
 At the start of the packet there is a u32 specifying the final length of the decompressed packet, so you know the size of the buffer to allocate and can check at the end if there was an error while decompressing (though this should never happen)
 

--- a/protocol/clientbound.md
+++ b/protocol/clientbound.md
@@ -56,7 +56,7 @@ reload()
 
 ## **`0x02` Compressed Packet**
 
-When a clientbound packet is big enough, the server sends you a compressed version of the packet instead. The compression algorithm used is LZ4, and it is explained [here](http://fastcompression.blogspot.com/2011/05/lz4-explained.html/).
+When a clientbound packet is big enough, the server sends you a compressed version of the packet instead. The compression algorithm used is LZ4, and it is explained [here](https://fastcompression.blogspot.com/2011/05/lz4-explained.html).
 
 At the start of the packet there is a u32 specifying the final length of the decompressed packet, so you know the size of the buffer to allocate and can check at the end if there was an error while decompressing (though this should never happen)
 


### PR DESCRIPTION
Updating the link used for LZ4 explanation. Current link returns a 404. The explanation on this link may not be comprehensive but  a new link is definitely needed. 